### PR TITLE
Network writer fix

### DIFF
--- a/martiniglass/src/cylinders_tcl.py
+++ b/martiniglass/src/cylinders_tcl.py
@@ -15,11 +15,9 @@
 import textwrap
 import numpy as np
 
-# positions = np.random.rand(10,2,3)
 
-# Function to parse a line based on field widths and types
 def parse_fixed_width_line(line):
-    #fixed widths in a gro file
+    # fixed widths in a gro file
     field_widths = [5, 5, 5, 5, 8, 8, 8, 8, 8, 8]  # Field widths derived from the C format specifiers
     field_types = ['int', 'str', 'str', 'int', 'float', 'float', 'float', 'float', 'float', 'float']  # Data types
     fields = []
@@ -38,10 +36,12 @@ def parse_fixed_width_line(line):
         start += width
     return fields
 
+
 def get_positions(coord_file):
     with open(coord_file, 'r') as f:
-        lines = [parse_fixed_width_line(i)[4:7] for i in f.readlines()[2:-1]] #gets the coordinates
+        lines = [parse_fixed_width_line(i)[4:7] for i in f.readlines()[2:-1]]  # gets the coordinates
     return np.array(lines)
+
 
 def file_write(coord_file, topology_contents, bonds_dictionary, mol_lens):
     """
@@ -54,43 +54,47 @@ def file_write(coord_file, topology_contents, bonds_dictionary, mol_lens):
     """
     coords = get_positions(coord_file)
 
+    # need to loop over this list because the order the topology file was processed in matters
+    mols_list = [i['name'] for i in topology_contents['molecules']]
+
     cylinder_string = "\n"
     start = 0
-    for mol in bonds_dictionary.keys():
+    for mol in mols_list:
         entry = [i for i in topology_contents['molecules'] if i['name'] == mol]
         n_mols = entry[0]['n_mols']
-        prev = start
 
-        #this is the starting indices of each molecule in the system
+        # this is the starting indices of each molecule in the system
         start_indices = np.arange(start, start+(int(n_mols) * int(mol_lens[mol])), int(mol_lens[mol]))
         start += int(n_mols) * int(mol_lens[mol])
 
+        cylinder_string += f"\n# starting bonds for {mol} here"
         for bond in bonds_dictionary[mol]:
 
             starts = np.array(start_indices+bond[0])
             ends = np.array(start_indices+bond[1])
-            coord_pairs = np.stack([[i,j] for i,j in zip(coords[starts], coords[ends])])
+            coord_pairs = np.stack([[i, j] for i, j in zip(coords[starts], coords[ends])])
 
             for position in coord_pairs:
-                #need the conversion here to make it back into gromacs for some reason
+                # need the conversion here to make it back into gromacs for some reason
                 pos0_str = ' '.join([f'{j*10:.3f}' for j in position[0]])
                 pos1_str = ' '.join([f'{j*10:.3f}' for j in position[1]])
 
-                cylinder_string+=(f'\ngraphics 0 cylinder "{pos0_str}" "{pos1_str}" radius $radius resolution 50')
+                cylinder_string += f'\ngraphics 0 cylinder "{pos0_str}" "{pos1_str}" radius $radius resolution 50'
 
-    msg=textwrap.dedent(
-    """
-    # Colour of the cylinder. 16 is black.
-    set colorID 16
-
-    # Cylinder radius 
-    set radius 0.3
-    
-    graphics 0 color $colorID"
-
-    # Draw a cylinder between the points listed
-    {cylinders}
-    """)
+    msg = textwrap.dedent(
+                            """
+                            # Colour of the cylinder. 16 is black.
+                            set colorID 16
+                        
+                            # Cylinder radius 
+                            set radius 0.3
+                            
+                            graphics 0 color $colorID"
+                        
+                            # Draw a cylinder between the points listed
+                            {cylinders}
+                            """
+                            )
 
     with open('network_cylinders.tcl', 'w') as f:
         f.write(textwrap.dedent(msg.format(cylinders=cylinder_string)))

--- a/martiniglass/src/topology.py
+++ b/martiniglass/src/topology.py
@@ -30,7 +30,7 @@ def input_topol_reader(file):
                 else:
                     go.append(line.split('"')[1])
             if mols:
-                if len(line.split()) > 0:
+                if (line.strip()[0] != ';') and (len(line.split()) > 0):
                     molecules.append({'name': line.split()[0],
                                       'n_mols': line.split()[1]})
             if 'molecules' in line:


### PR DESCRIPTION
fix the todo for the excess bond handling in the network writer analysis.

Before, a complex method of looking at all the nodes was used. This then iterated slowly over all the nodes in the graph and checked how many needed to be removed.

Now the graph is used more directly (and efficiently) to remove the number of edges between nodes in one go, which reduces the error handling we need