### PR TITLE
Fix IndexError in topology parser when encountering empty lines

### DIFF
--- a/martiniglass/src/topology.py
+++ b/martiniglass/src/topology.py
@@ -27,9 +27,12 @@ def input_topol_reader(file):
             if '#include' in line:
                 inclusions.append(line.split('"')[1])
             if mols:
-                if (line.strip()[0] != ';') and (len(line.split()) > 0):
-                    molecules.append({'name': line.split()[0],
-                                      'n_mols': line.split()[1]})
+                if (line.strip() and (line.split()[0]) != ';'):
+                    molecules.append({
+			'name': line.split()[0],
+                        'n_mols': line.split()[1]
+		    })
+
             if 'molecules' in line:
                 mols = True
                 sys = False


### PR DESCRIPTION
This PR fixes a bug in the file `topology.py` of MartiniGlass. The function `input_topol_reader` previously assumed that every line in a topology file contained at least one character:

`if (line.strip()[0] != ';') and (len(line.split()) > 0):`

Empty lines caused an IndexError because [0] was accessed on an empty string.

The fix adds a check to ensure the line is not empty before accessing the first character:

```python
if (line.strip() and (line.split()[0]) != ';'):
    molecules.append({
        'name': line.split()[0],
        'n_mols': line.split()[1]
    })
```
This ensures that only non-empty lines are processed, allowing the parser to safely skip empty lines.